### PR TITLE
Ajustes en la traducción

### DIFF
--- a/content/es-AR/index.smd
+++ b/content/es-AR/index.smd
@@ -1,7 +1,7 @@
 ---
 .title = "Inicio",
 .author = "",
-.date = @date("2024-10-06:00:00:00"),
+.date = @date("2024-08-07:00:00:00"),
 .layout = "index.shtml",
 .custom = {
 	"mobile_menu_title": "Inicio",
@@ -9,56 +9,56 @@
 ---
 
 []($section.id("slogan"))
-Zig es un lenguaje de programación de propósito general y una cadena de herramientas para mantener software **robusto**, **óptimo** y **reusable**.
+Zig es un lenguaje de programación de propósito general y un conjunto de herramientas para mantener software **robusto**, **óptimo** y **reutilizable**.
 
 []($section.id("features"))
-# ⚡ Un Lenguaje Simple
-Enfócate en depurar tu aplicación en vez de depurar tu conocimiento del lenguaje
+## ⚡ Un Lenguaje Sencillo
+Céntrate en depurar tu aplicación y no tu conocimiento del lenguaje de programación.
 
 - Sin control de flujo oculto.
-- Sin asignaciones de memoria ocultas
+- Sin asignaciones de memoria ocultas.
 - Sin preprocesador, sin macros.
 
-# ⚡ Comptime
-Un enfoque fresco hacia la meta-programación basada en ejecución de código en tiempo de compilación y evaluación tardía (lazy evaluation).
+## ⚡ Comptime
+Un enfoque fresco a la metaprogramación basada en ejecución de código en tiempo de compilación y evaluación tardía.
 
 - Llama cualquier función en tiempo de compilación.
-- Manipula tipos como si fuesen valores sin penalizar el tiempo de ejecución.
-- Comptime emula la arquitectura objetivo.
+- Manipula tipos como si fueran valores sin penalizar el tiempo de ejecución.
+- Comptime emula la arquitectura de destino.
 
 ## ⚡ Mantenlo con Zig
-Mejora incrementalmente tu base de código C/C++/Zig.
+Mejora gradualmente tu base de código en C/C++/Zig.
 
-- Usa Zig como un compilador de cero dependencia, para C/C++, que soporta compilación cruzada(cross-compilation) a la primera.
-- Apóyate en `zig build` para crear un ambiente de desarrollo consistente para todas las plataformas.
-- Añade una unidad de compilación Zig a tus proyectos en C/C++, exponiendo una librería estándar rica para tu código C/C++.
+- Usa Zig como un sustituto de compilador de C/C++ que no tiene dependencias externas y permite la compilación cruzada de fábrica.
+- Aprovéchate de `zig build` para crear un entorno de desarrollo consistente para todas las plataformas.
+- Añade una unidad de compilación de Zig a tus proyectos en C/C++, exponiéndolos a su extensa librería estándar.
 
 
 # [Comunidad]($section.id("community").attrs("section-title"))
 
-## [La comunidad Zig es descentralizada]($section.id("decentralized"))
-Quien desee, es libre de iniciar y mantener su lugar propio de reunión.
-No existe el concepto de "oficial" o "no oficial", no obstante, cada lugar de reunión tiene sus propias reglas y moderadores.
+## [La comunidad de Zig es descentralizada]($section.id("decentralized"))
+Todo el mundo es libre de iniciar y mantener su propio lugar de reunión para la comunidad.
+No existe el concepto de "oficial" o "no oficial". No obstante, cada lugar de reunión tiene sus propias reglas y moderadores.
 
 
 ## [Desarrollo principal]($section.id("main-development"))
-El repositorio de Zig se encuentra en [https://github.com/ziglang/zig](https://github.com/ziglang/zig), donde también damos seguimiento a errores y discusiones de propuestas.
-Se espera que quienes contribuyen, sigan el [Código de conducta de Zig](https://github.com/ziglang/zig/blob/master/.github/CODE_OF_CONDUCT.md).
+El repositorio de Zig se encuentra en [https://github.com/ziglang/zig](https://github.com/ziglang/zig), donde también hospedamos el seguimiento de incidencias y discutimos propuestas.
+Se espera que los contribuidores sigan el [Código de Conducta](https://github.com/ziglang/zig/blob/master/.github/CODE_OF_CONDUCT.md) de Zig.
 
 
 # [Zig Software Foundation]($section.id("zsf").attrs("section-title"))
 
-## La ZSF es una corporación sin fines de lucro 501(c)(3).
+## La ZSF es una corporación 501(c)(3) sin ánimo de lucro.
 
-La Zig Software Foundation es una corporación sin fines de lucro fundada en 2020 por Andrew Kelly, el creador de Zig, con el fin de sostener el desarrollo del lenguaje. Actualmente, la ZSF es capaz de ofrecer empleo con remuneración competitiva a un pequeño número de contribuyentes. Esperamos ser capaces de extender esta oferta a más contribuyentes en el futuro.
+La Zig Software Foundation es una corporación sin ánimo de lucro fundada en 2020 por Andrew Kelly, el creador de Zig, con el fin de sostener el desarrollo del lenguaje. Actualmente, la ZSF es capaz de ofrecer empleo con remuneración competitiva a un pequeño número de contribuidores principales. Esperamos ser capaces de extender esta oferta a más contribuidores en el futuro.
 
 La Zig Software Foundation se mantiene con donaciones.
 
-# [Patrocinadores]($section.id("sponsors").attrs("section-title"))
+# [Mecenas]($section.id("sponsors").attrs("section-title"))
 
-## [Patrocinadores Corporativos]($section.id("corporate-sponsors"))
-Las siguientes compañías proveen apoyo económico directo a la Zig Software Foundation.
+## [Mecenas Corporativos]($section.id("corporate-sponsors"))
+Las empresas a continuación proveen apoyo económico directo a la Zig Software Foundation.
 
-## [Patrocinadores en GitHub]($section.id("github-sponsors"))
-Gracias a las [personas que patrocinan Zig]($link.page('zsf')), el proyecto se debe a la comunidad open source y no a entes corporativos. En particular, estos queridos amigos patrocinan a Zig por un monto de $200 USD mensuales o más:
+## [Mecenas en GitHub]($section.id("github-sponsors"))
+Gracias a las personas que [donan a Zig]($link.page('zsf')), el proyecto se debe a la comunidad open source y no a entes corporativos. En particular, estas buenas personas donan a Zig al menos $200 USD mensuales:
 


### PR DESCRIPTION
Hola. Te presento mis propuestas a la traducción de la web de Zig.

Revisar traducciones puede llevarme bastante tiempo, unos cuantos días por documento. Aunque puedo justificar cada cambio que propongo, me llevaría bastante más tiempo hacerlo de antemano así que me arriesgaré y trataré de justificar las dudas o críticas que puedas tener en cada ocasión.

En general, estas son las normas de estilo que intentaré seguir para cada documento:

* La voz siempre será de _tú_. Ni _vos_, ni _usted_. El singular mayestático siempre se referirá a la ZSF, a los core maintainers, o en definitiva a la organización y personas que mantienen Zig en su conjunto.
* No usaré anglicismos y en la mayoría de casos los eliminaré, excepto en las palabras clave o nombres propios que lo requieran. Hay conceptos que no se pueden traducir y para ello me ayudaré de la Wikipedia en varios idiomas y cogeré el que parezca más apto.
* El pretérito imperfecto subjuntivo siempre usará la forma `-ra`. Me reservo la partícula `se` para otras ocasiones.
* Mantendré el máximo de simetría posible con la versión original en inglés. Esto aplica a palabras que son enlaces, niveles de los títulos, saltos de línea, etc. Esto ayuda a comparar las traducciones en solapa.
* De manera puntual me doy libertad creativa para ajustar una línea de texto al espacio real que ocupa vista en el navegador.
* ¡Tengo sesgos! Me he esforzado al máximo en no usar locuciones u otras expresiones habituales del español peninsular pero puede que en algunas propuestas no lo haga con éxito. Confío en que puedas avisarme cuando se dé el caso. Es la primera vez que intento hacer una traducción adaptada al español neutro.

Iré actualizando esta PR a medida que vaya revisando más documentos. Siéntete libre de compartir cualquier duda o crítica que tengas (tú o la comunidad de Telegram, a la que desafortunadamente no me uniré porque prefiero el formato foro de toda la vida).